### PR TITLE
Changed shape of affine matrix to (4,3) to align with expected input to neuroglancer

### DIFF
--- a/code/atlas_builder/template.py
+++ b/code/atlas_builder/template.py
@@ -109,7 +109,8 @@ class Template(AtlasAsset):
             if scale_vec is not None:
                 scale_transforms.append({"type": "scale", "scale": scale_vec.tolist()})
             if flip_mat is not None:
-                scale_transforms.append({"type": "affine", "affine": flip_mat.tolist()})
+                flip_mat_affine = np.hstack([flip_mat, np.zeros((3, 1))]).tolist() # Zero padding affine to be of shape (3,4)
+                scale_transforms.append({"type": "affine", "affine": flip_mat_affine})
             if rotation_mat is not None:
                 scale_transforms.append({"type": "rotation", "rotation": rotation_mat.tolist()})
             if translation_vec is not None:


### PR DESCRIPTION
I **think** this is the only change needed to get the HMBA atlases working. RFC-5 expects an array of shape (3,4) so I just zero-padded the affine. 